### PR TITLE
Added setting to save OpenKeychain auth keyid

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
@@ -84,6 +84,13 @@ class UserPreference : AppCompatActivity() {
                         true
                     }
 
+            findPreference("ssh_openkeystore_clear_keyid").onPreferenceClickListener =
+                    Preference.OnPreferenceClickListener {
+                        sharedPreferences.edit().putString("ssh_openkeystore_keyid", null).apply()
+                        it.isEnabled = false
+                        true
+                    }
+
             findPreference("git_server_info").onPreferenceClickListener = Preference.OnPreferenceClickListener {
                 val intent = Intent(callingActivity, GitActivity::class.java)
                 intent.putExtra("Operation", GitActivity.EDIT_SERVER)
@@ -190,6 +197,10 @@ class UserPreference : AppCompatActivity() {
             )?.isNotEmpty() ?: false
             findPreference("hotp_remember_clear_choice").isEnabled =
                     sharedPreferences.getBoolean("hotp_remember_check", false)
+            findPreference("ssh_openkeystore_clear_keyid").isEnabled = sharedPreferences.getString(
+                    "ssh_openkeystore_keyid",
+                    null
+            )?.isNotEmpty() ?: false
             findPreference("clear_after_copy").isEnabled = sharedPreferences.getString("general_show_time", "45")?.toInt() != 0
             findPreference("clear_clipboard_20x").isEnabled = sharedPreferences.getString("general_show_time", "45")?.toInt() != 0
             val keyPref = findPreference("openpgp_key_id_pref")

--- a/app/src/main/java/com/zeapo/pwdstore/git/CloneOperation.java
+++ b/app/src/main/java/com/zeapo/pwdstore/git/CloneOperation.java
@@ -70,6 +70,8 @@ public class CloneOperation extends GitOperation {
 
     @Override
     public void onError(String errorMessage) {
+        super.onError(errorMessage);
+
         new AlertDialog.Builder(callingActivity).
                 setTitle(callingActivity.getResources().getString(R.string.jgit_error_dialog_title)).
                 setMessage("Error occured during the clone operation, "

--- a/app/src/main/java/com/zeapo/pwdstore/git/GitActivity.java
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitActivity.java
@@ -703,8 +703,8 @@ public class GitActivity extends AppCompatActivity {
         }
     }
 
-    protected void onActivityResult(int requestCode, int resultCode,
-                                    Intent data) {
+    public void onActivityResult(int requestCode, int resultCode,
+                                 Intent data) {
 
         // In addition to the pre-operation-launch series of intents for OpenKeychain auth
         // that will pass through here and back to launchGitOperation, there is one
@@ -712,8 +712,16 @@ public class GitActivity extends AppCompatActivity {
         // background thread - the actual signing of the SSH challenge. We pass through the
         // completed signature to the ApiIdentity, which will be blocked in the other thread
         // waiting for it.
-        if (requestCode == SshApiSessionFactory.POST_SIGNATURE && identity != null)
+        if (requestCode == SshApiSessionFactory.POST_SIGNATURE && identity != null) {
             identity.postSignature(data);
+
+            // If the signature failed (usually because it was cancelled), reset state
+            if (data == null) {
+                identity = null;
+                identityBuilder = null;
+            }
+            return;
+        }
 
         if (resultCode == RESULT_CANCELED) {
             setResult(RESULT_CANCELED);

--- a/app/src/main/java/com/zeapo/pwdstore/git/GitOperation.java
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitOperation.java
@@ -239,13 +239,11 @@ public abstract class GitOperation {
      * Action to execute on error
      */
     public void onError(String errorMessage) {
-        new AlertDialog.Builder(callingActivity).
-                setTitle(callingActivity.getResources().getString(R.string.jgit_error_dialog_title)).
-                setMessage(callingActivity.getResources().getString(R.string.jgit_error_dialog_text) + errorMessage).
-                setPositiveButton(callingActivity.getResources().getString(R.string.dialog_ok), (dialogInterface, i) -> {
-                    callingActivity.setResult(Activity.RESULT_CANCELED);
-                    callingActivity.finish();
-                }).show();
+        if (SshSessionFactory.getInstance() instanceof SshApiSessionFactory) {
+            // Clear stored keyid from settings on auth failure
+            PreferenceManager.getDefaultSharedPreferences(callingActivity.getApplicationContext())
+                    .edit().putString("ssh_openkeystore_keyid", null).apply();
+        }
     }
 
     /**

--- a/app/src/main/java/com/zeapo/pwdstore/git/PullOperation.java
+++ b/app/src/main/java/com/zeapo/pwdstore/git/PullOperation.java
@@ -43,6 +43,8 @@ public class PullOperation extends GitOperation {
 
     @Override
     public void onError(String errorMessage) {
+        super.onError(errorMessage);
+
         new AlertDialog.Builder(callingActivity).
                 setTitle(callingActivity.getResources().getString(R.string.jgit_error_dialog_title)).
                 setMessage("Error occured during the pull operation, "

--- a/app/src/main/java/com/zeapo/pwdstore/git/PushOperation.java
+++ b/app/src/main/java/com/zeapo/pwdstore/git/PushOperation.java
@@ -44,6 +44,9 @@ public class PushOperation extends GitOperation {
     @Override
     public void onError(String errorMessage) {
         // TODO handle the "Nothing to push" case
+
+        super.onError(errorMessage);
+
         new AlertDialog.Builder(callingActivity).
                 setTitle(callingActivity.getResources().getString(R.string.jgit_error_dialog_title)).
                 setMessage(callingActivity.getString(R.string.jgit_error_push_dialog_text) + errorMessage).

--- a/app/src/main/java/com/zeapo/pwdstore/git/SyncOperation.java
+++ b/app/src/main/java/com/zeapo/pwdstore/git/SyncOperation.java
@@ -55,6 +55,8 @@ public class SyncOperation extends GitOperation {
 
     @Override
     public void onError(String errorMessage) {
+        super.onError(errorMessage);
+
         new AlertDialog.Builder(callingActivity).
                 setTitle(callingActivity.getResources().getString(R.string.jgit_error_dialog_title)).
                 setMessage("Error occured during the sync operation, "

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -262,4 +262,5 @@
     <string name="sdcard_root_warning_title">SD-Card root selected</string>
     <string name="sdcard_root_warning_message">You have selected the root of your sdcard for the store. This is extremely dangerous and you will lose your data as its content will, eventually, be deleted</string>
     <string name="git_abort_and_push_title">Abort and Push</string>
+    <string name="ssh_openkeystore_clear_keyid">Clear remembered OpenKeystore SSH Key ID</string>
 </resources>

--- a/app/src/main/res/xml/preference.xml
+++ b/app/src/main/res/xml/preference.xml
@@ -20,6 +20,9 @@
             android:key="hotp_remember_clear_choice"
             android:title="@string/hotp_remember_clear_choice" />
         <Preference
+            android:key="ssh_openkeystore_clear_keyid"
+            android:title="@string/ssh_openkeystore_clear_keyid" />
+        <Preference
             android:key="ssh_see_key"
             android:title="@string/pref_ssh_see_key_title" />
         <Preference


### PR DESCRIPTION
After a successful authentication using OpenKeystore, the selected keyid is now saved in the settings and used automatically for future authentications.

The saved keyid is cleared automatically after an authentication failure or if that key is no longer found. It can also be cleared manually through the settings screen.

Also fixes a potential NPE crash if OpenKeychain authentication was canceled at certain spots.